### PR TITLE
[ENHANCE] modal_form.js: add returned data to post success callback func...

### DIFF
--- a/FormJsBundle/Resources/public/js/modal_form.js
+++ b/FormJsBundle/Resources/public/js/modal_form.js
@@ -34,13 +34,13 @@
             form.serialize(),
             function(data) {
                 if(data.hasOwnProperty('error')) {
-                    $(trigger).trigger('modalform.post_error');
+                    $(trigger).trigger('modalform.post_error', data);
                     form.mapErrors(data.error);
                     handleErrors();
                 }else {
-                    $(trigger).trigger('modalform.post_success');
+                    $(trigger).trigger('modalform.post_success', data);
                     modal.modal('hide');
-                    trigger.trigger('modalform.after_modal_hide');
+                    trigger.trigger('modalform.after_modal_hide', data);
                 }
             }
         );


### PR DESCRIPTION
Als je het data object terug meegeeft aan de events die je triggered in de post.success callback function, dan kan je daar in de code ook weer iets mee doen.

vb.
.bind('modalform.post_success', function(event, data) {
      console.log('do something with the ', data);
    });
