### PR TITLE
Change default value of cache option

### DIFF
--- a/FormJsBundle/Resources/public/js/modal_form.js
+++ b/FormJsBundle/Resources/public/js/modal_form.js
@@ -12,7 +12,7 @@
                 submit_selector: ':submit',
                 title: '',
                 modal_id: modalId,
-                cache: true
+                cache: false
             };
 
             var mergedOptions = $.extend(defaults, options);


### PR DESCRIPTION
Problem.
Doet zicht enkel voor in IE.
Modal form met daarin een selectbox die beschikbare personen bevat.
Als gebruiker zie ik dat de persoon die ik wil selecteren nog niet bestaat.
Ik maak de persoon aan en open de modal form opnieuw.
De persoon is nog steeds niet zichtbaar in de selectbox.

Cause
IE cached GET ajax requests. In bovenstaand scenario, wanneer je de ajax GET request stuurt (om de form te zien te krijgen), zal IE een 302 Not Modified response sturen. Je krijgt dus de cached versie van het formulier te zien.

Oplossing
jQuery.ajax voorziet de cache optie, zodat je cache kan forcen. Dit staat default op true (IE zal dus nog steeds cachen).
We hebben deze cache optie ook beschikbaar gemaakt in de modalform (589b7ef7bb6bcbf86376b74d13450e137304f046).

In Pringles krijgen we gigantisch veel meldingen van dit probleem, wij moeten praktisch voor elke modal form de optie "cache: false" meegeven.

De vraag is dus, mag ik de default value van "cache" aanpassen naar false?
